### PR TITLE
added exception handling to tell user port used

### DIFF
--- a/GoFundMeServer.java
+++ b/GoFundMeServer.java
@@ -36,6 +36,9 @@ public class GoFundMeServer {
                 Socket clientSocket = serverSocket.accept();
                 new ClientHandler(clientSocket).start();
             }
+        } catch (BindException e) {
+            System.err.println("---------------------------------");
+            System.err.println("Could not start the server. Port " + PORT + " is already in use.");
         } catch (IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
This PR introduces improved handling of the `java.net.BindException` within the `GoFundMeServer` application. Previously, attempting to launch the server on a port already in use would result in an unhandled exception and termination of the program. The enhancements in this PR provide a more robust solution. 

Key changes include:
- Catching `BindException` specifically during the server startup process.
- Upon catching the exception, a user-friendly message is displayed, suggesting the port is already in use.
